### PR TITLE
Finalized pal and lctwp command

### DIFF
--- a/include/reptorian.gmic
+++ b/include/reptorian.gmic
@@ -216,24 +216,18 @@ palette_transfer:
 _iw={w}
 _ih={h}
 _CI={$2}
-mode="-1"
-ti="i"
-tn="-1"
-_test_a={${ti}==${mode}}
-_test_b={${tn}==${mode}}
-_test_c={${_test_a}||${_test_b}}
 skip ${4=2},${5=0},${6=.5},${7=0},${8=1},${9=1},${10=0},${11=32},${12=32},${13=1},${14=0},${15=0}
 AlpC=$4 AlpD=$5 SF=$6
-if $_test_c pal $1 fi
+pal $1
 if $7 r[0] {100/$8}%,{100/$9}%,1,4,$7 fi
 split_opacity[0]
-l[^1] if !$_test_c pal $1 fi if {$_CI==0} if {$10>1} l[0] at "autoindex $10,$13,$14",$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm.
+l[^1] if {$_CI==0} if {$10>1} l[0] at "autoindex $10,$13,$14",$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm.
 elif {$_CI==1} to_rgba ${_iw},${_ih},1,4 noise. {$SF*75} to_graya. blend[^1] difference,1 to_rgb if {$10>1} l[0] at "autoindex $10,$13,$14",$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm.
 elif {$_CI==2} pal 0 [0] index. ..,1,1 rm.. +blend[^1] interpolation,$4 rm[0,2] rv if l[0] at "autoindex $10,$13,$14",$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm.
 else if {$CI>2} if {($_CI-3)==0} +f[0] "x%2*255" else +f[0] "y%2*255" fi fi blend[^1] multiply,{$SF/20} if {$10>1} l[0] at "autoindex $10,$13,$14",$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm. fi 
 endl
 if {$4<2} rm. if $7 r {100*$8}%,{100*$9}%,1,3,1 fi else
-l[1] ${AlpC},1,1,1 f. "x" n. 0,255 if {$10>1} l[0] at "autoindex $10,${AlpD},$15",$11,$12,,,,,3 endl index.. .,0,1 else index.. .,${AlpD},1 fi rm. endl a c if $7 r {100*$8}%,{100*$9}%,1,4,1 fi fi
+l[1] ${AlpC},1,1,1 f. "x" n. 0,255 if {$10>1&&$4>2} l[0] at "autoindex $10,${AlpD},$15",$11,$12,,,,,3 endl index.. .,0,1 else index.. .,${AlpD},1 fi rm. endl a c if $7 r {100*$8}%,{100*$9}%,1,4,1 fi fi
 #@cli sol : eq. to '_solarize'.
 sol :
 _solarize

--- a/include/reptorian.gmic
+++ b/include/reptorian.gmic
@@ -206,31 +206,34 @@ _pal_jmp:
 _pal_mac2: (255,255,255,220,255,54,0,0,0,0,101,151,185,134,69,0^255,255,101,0,0,0,0,151,168,101,54,101,185,134,69,0^255,0,0,0,151,151,202,255,0,0,0,54,185,134,69,0)
 _pal_secam: (0,33,240,255,127,127,255,255^0,33,60,80,255,255,255,255^0,255,121,255,0,255,63,255)
 _pal_jewel: (50,102,184,210,242,240,223,188,121,86,74,77,115,116,156^30,36,40,106,197,232,183,123,65,96,143,193,227,130,172^45,49,28,18,60,156,127,98,107,148,169,179,123,161,186)
-#@cli lctwp : eq. to 'low_color_transfer_with_palette'
-lctwp: low_color_transfer_with_palette $*
-#@cli : low_color_transfer_with_palette
+#@cli pal_t : eq. to 'palette_transfer'
+pal_t: palette_transfer $*
+#@cli : palette_transfer
 #@cli : Transfer Colors to images using a palette. If using negative number or "i" for first variable, there must be exactly two layers. Else, they must be performed per 1 layers in a loop if one were to apply palette transfer among multiple layers! 
-#@cli : For 2 layers where one is a palette - $ low_color_transfer_with_palette -1,0,.5
-#@cli : To apply palette colors to multiple layers - $ repeat $! l[$<] low_color_transfer_with_palette db32,0,.5 endl done
-low_color_transfer_with_palette: 
+#@cli : For 2 layers where one is a palette - $ palette_transfer -1,0,.5
+#@cli : To apply palette colors to multiple layers - $ repeat $! l[$<] palette_transfer db32,0,.5 endl done
+palette_transfer:
 _iw={w}
 _ih={h}
 _CI={$2}
-Palette=$1
-if {isval($1)} if {$1<0} Palette=-1 else Palette=1 fi else if {"$1"="i"} Palette=1 else Palette=-1 fi fi
-skip ${4=2},${5=0},${6=.5},${7=0},${8=1},${9=1},${10=0},${11=32},${12=32},${13=1},${14=0}
+mode="-1"
+ti="i"
+tn="-1"
+_test_a={${ti}==${mode}}
+_test_b={${tn}==${mode}}
+_test_c={${_test_a}||${_test_b}}
+skip ${4=2},${5=0},${6=.5},${7=0},${8=1},${9=1},${10=0},${11=32},${12=32},${13=1},${14=0},${15=0}
 AlpC=$4 AlpD=$5 SF=$6
-if {$4<2} v + error "Error: 4th input cannot be set to less than 2!" fi
-if {$Palette==-1} pal -1 fi
+if $_test_c pal $1 fi
 if $7 r[0] {100/$8}%,{100/$9}%,1,4,$7 fi
 split_opacity[0]
-l[^1] if {$Palette!=-1} pal $1 fi if {$_CI==0} if {$10>1} l[0] at "autoindex $10,$13,$14",$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm.
+l[^1] if !$_test_c pal $1 fi if {$_CI==0} if {$10>1} l[0] at "autoindex $10,$13,$14",$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm.
 elif {$_CI==1} to_rgba ${_iw},${_ih},1,4 noise. {$SF*75} to_graya. blend[^1] difference,1 to_rgb if {$10>1} l[0] at "autoindex $10,$13,$14",$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm.
 elif {$_CI==2} pal 0 [0] index. ..,1,1 rm.. +blend[^1] interpolation,$4 rm[0,2] rv if l[0] at "autoindex $10,$13,$14",$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm.
 else if {$CI>2} if {($_CI-3)==0} +f[0] "x%2*255" else +f[0] "y%2*255" fi fi blend[^1] multiply,{$SF/20} if {$10>1} l[0] at "autoindex $10,$13,$14",$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm. fi 
 endl
-l[1] ${AlpC},1,1,1 f. "x" n. 0,255 index.. .,${AlpD},1 rm. endl a c
-if $7 r {100*$8}%,{100*$9}%,1,4,1 fi
+if {$4<2} rm. if $7 r {100*$8}%,{100*$9}%,1,3,1 fi else
+l[1] ${AlpC},1,1,1 f. "x" n. 0,255 if {$10>1} l[0] at "autoindex $10,${AlpD},$15",$11,$12,,,,,3 endl index.. .,0,1 else index.. .,${AlpD},1 fi rm. endl a c if $7 r {100*$8}%,{100*$9}%,1,4,1 fi fi
 #@cli sol : eq. to '_solarize'.
 sol :
 _solarize

--- a/include/reptorian.gmic
+++ b/include/reptorian.gmic
@@ -224,10 +224,10 @@ if {$4<2} v + error "Error: 4th input cannot be set to less than 2!" fi
 if {$Palette==-1} pal -1 fi
 if $7 r[0] {100/$8}%,{100/$9}%,1,4,$7 fi
 split_opacity[0]
-l[^1] if {$Palette!=-1} pal $1 fi if {$_CI==0} if {$10>1} l[0] at "autoindex $10,$13,$14"$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm.
-elif {$_CI==1} to_rgba ${_iw},${_ih},1,4 noise. {$SF*75} to_graya. blend[^1] difference,1 to_rgb if {$10>1} l[0] at "autoindex $10,$13,$14"$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm.
-elif {$_CI==2} pal 0 [0] index. ..,1,1 rm.. +blend[^1] interpolation,$4 rm[0,2] rv if l[0] at "autoindex $10,$13,$14"$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm.
-else if {$CI>2} if {($_CI-3)==0} +f[0] "x%2*255" else +f[0] "y%2*255" fi fi blend[^1] multiply,{$SF/20} if {$10>1} l[0] at "autoindex $10,$13,$14"$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm. fi 
+l[^1] if {$Palette!=-1} pal $1 fi if {$_CI==0} if {$10>1} l[0] at "autoindex $10,$13,$14",$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm.
+elif {$_CI==1} to_rgba ${_iw},${_ih},1,4 noise. {$SF*75} to_graya. blend[^1] difference,1 to_rgb if {$10>1} l[0] at "autoindex $10,$13,$14",$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm.
+elif {$_CI==2} pal 0 [0] index. ..,1,1 rm.. +blend[^1] interpolation,$4 rm[0,2] rv if l[0] at "autoindex $10,$13,$14",$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm.
+else if {$CI>2} if {($_CI-3)==0} +f[0] "x%2*255" else +f[0] "y%2*255" fi fi blend[^1] multiply,{$SF/20} if {$10>1} l[0] at "autoindex $10,$13,$14",$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm. fi 
 endl
 l[1] ${AlpC},1,1,1 f. "x" n. 0,255 index.. .,${AlpD},1 rm. endl a c
 if $7 r {100*$8}%,{100*$9}%,1,4,1 fi

--- a/include/reptorian.gmic
+++ b/include/reptorian.gmic
@@ -38,6 +38,13 @@
 #  knowledge of the CeCILL license and that you accept its terms.
 #
 
+#-------------------------------
+#
+#@cli :: Reptorian's CLI Commands
+#
+#-------------------------------
+
+
 #@cli pal :
 #@cli : Creates pre-made user-made palette or palette that are based off older system.
 pal:

--- a/include/reptorian.gmic
+++ b/include/reptorian.gmic
@@ -51,7 +51,7 @@ mode=${arg\ 1+$1,bw,rgb,b_rgb,bw_rgb,cmy,cmyk,wcmyk,rgbcmy,1bitrgb,aurora,playpa
 fi fi fi
 v + e[^-1] "Create palette '"$mode"' for pixel art or effect."$_gmic_s"." v -
 _pal_$mode
-_pal_i: if {$!==2} +autocrop _ia={w#2*h#2} _ib={w#3*h#3} rm[^0-1] if {$_ia<$_ib} rv fi l[1] fx_extract_objects 0,0,0,0,0,0,1 rm. s y autocrop 0,0,0,0 a x to_rgb if {w>1024} v + error "ERROR: Too much colors in palette! Please reduce colors!" fi endl else v + error "ERROR: Need two layers for command to work!" fi
+_pal_i: if {$!==2} if {h#1!=1 && h#0!=1} +autocrop _ia={w#2*h#2} _ib={w#3*h#3} rm[^0-1] if {$_ia<$_ib} rv fi l[1] fx_extract_objects 0,0,0,0,0,0,1 rm. s y autocrop 0,0,0,0 a x to_rgb if {w>1024} v + error "ERROR: Too much colors in palette! Please reduce colors!" fi endl else +autocrop _ia={w#2*h#2} _ib={w#3*h#3} rm[^0-1] if {$_ia<$_ib} rv fi to_rgb[1] if {w#1>1024} v + error "ERROR: Too much colors in palette! Please reduce colors!" fi fi else v + error "ERROR: Need two layers for command to work!" fi
 _pal_polar11: (10,171,209,245,245,135,153,95,51,45,47^10,41,105,202,241,140,194,148,157,98,43^10,41,31,47,237,129,78,72,181,150,107)
 _pal_rust6: (35,113,165,225,240,255^0,47,73,136,187,226^0,48,50,102,156,198)
 _pal_cave: (0,16,54,68,143,199,156,245^0,0,29,63,86,144,228,245^0,41,35,79,179,101,199,245)
@@ -211,17 +211,19 @@ _ih={h}
 _CI={$2}
 Palette=$1
 if {isval($1)} if {$1<0} Palette=-1 else Palette=1 fi else if {"$1"="i"} Palette=1 else Palette=-1 fi fi
-skip ${4=2},${5=0},${6=.5}
+skip ${4=2},${5=0},${6=.5},${7=0},${8=1},${9=1},${10=0},${11=32},${12=32},${13=1},${14=0}
 AlpC=$4 AlpD=$5 SF=$6
 if {$4<2} v + error "Error: 4th input cannot be set to less than 2!" fi
 if {$Palette==-1} pal -1 fi
+if $7 r[0] {100/$8}%,{100/$9}%,1,4,$7 fi
 split_opacity[0]
-l[^1] if {$Palette!=-1} pal $1 fi if {$_CI==0} index.. .,$3,1 rm.
-elif {$_CI==1} to_rgba ${_iw},${_ih},1,4 noise. {$SF*75} to_graya. blend[^1] difference,1 to_rgb index.. .,$3,1 rm.
-elif {$_CI==2} pal 0 [0] index. ..,1,1 rm.. +blend[^1] interpolation,$4 rm.. index. ..,$3,1 k.
-else if {$CI>2} if {($_CI-3)==0} +f[0] "x%2*255" else +f[0] "y%2*255" fi fi blend[^1] multiply,{$SF/20} index.. .,$3,1 rm. fi 
+l[^1] if {$Palette!=-1} pal $1 fi if {$_CI==0} if {$10>1} l[0] at "autoindex $10,$13,$14"$11,$12 endl index.. .,0,1 else index.. .,$3,1 fi rm.
+elif {$_CI==1} to_rgba ${_iw},${_ih},1,4 noise. {$SF*75} to_graya. blend[^1] difference,1 to_rgb if {$10>1} l[0] at "autoindex $10,$13,$14"$11,$12 endl index.. .,0,1 else index.. .,$3,1 fi rm.
+elif {$_CI==2} pal 0 [0] index. ..,1,1 rm.. +blend[^1] interpolation,$4 rm[0,2] rv if l[0] at "autoindex $10,$13,$14"$11,$12 endl index.. .,0,1 else index.. .,$3,1 fi rm.
+else if {$CI>2} if {($_CI-3)==0} +f[0] "x%2*255" else +f[0] "y%2*255" fi fi blend[^1] multiply,{$SF/20} if {$10>1} l[0] at "autoindex $10,$13,$14"$11,$12 endl index.. .,0,1 else index.. .,$3,1 fi rm. fi 
 endl
 l[1] ${AlpC},1,1,1 f. "x" n. 0,255 index.. .,${AlpD},1 rm. endl a c
+if $7 r {100*$8}%,{100*$9}%,1,4,1 fi
 #@cli sol : eq. to '_solarize'.
 sol :
 _solarize

--- a/include/reptorian.gmic
+++ b/include/reptorian.gmic
@@ -224,10 +224,10 @@ if {$4<2} v + error "Error: 4th input cannot be set to less than 2!" fi
 if {$Palette==-1} pal -1 fi
 if $7 r[0] {100/$8}%,{100/$9}%,1,4,$7 fi
 split_opacity[0]
-l[^1] if {$Palette!=-1} pal $1 fi if {$_CI==0} if {$10>1} l[0] at "autoindex $10,$13,$14"$11,$12 endl index.. .,0,1 else index.. .,$3,1 fi rm.
-elif {$_CI==1} to_rgba ${_iw},${_ih},1,4 noise. {$SF*75} to_graya. blend[^1] difference,1 to_rgb if {$10>1} l[0] at "autoindex $10,$13,$14"$11,$12 endl index.. .,0,1 else index.. .,$3,1 fi rm.
-elif {$_CI==2} pal 0 [0] index. ..,1,1 rm.. +blend[^1] interpolation,$4 rm[0,2] rv if l[0] at "autoindex $10,$13,$14"$11,$12 endl index.. .,0,1 else index.. .,$3,1 fi rm.
-else if {$CI>2} if {($_CI-3)==0} +f[0] "x%2*255" else +f[0] "y%2*255" fi fi blend[^1] multiply,{$SF/20} if {$10>1} l[0] at "autoindex $10,$13,$14"$11,$12 endl index.. .,0,1 else index.. .,$3,1 fi rm. fi 
+l[^1] if {$Palette!=-1} pal $1 fi if {$_CI==0} if {$10>1} l[0] at "autoindex $10,$13,$14"$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm.
+elif {$_CI==1} to_rgba ${_iw},${_ih},1,4 noise. {$SF*75} to_graya. blend[^1] difference,1 to_rgb if {$10>1} l[0] at "autoindex $10,$13,$14"$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm.
+elif {$_CI==2} pal 0 [0] index. ..,1,1 rm.. +blend[^1] interpolation,$4 rm[0,2] rv if l[0] at "autoindex $10,$13,$14"$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm.
+else if {$CI>2} if {($_CI-3)==0} +f[0] "x%2*255" else +f[0] "y%2*255" fi fi blend[^1] multiply,{$SF/20} if {$10>1} l[0] at "autoindex $10,$13,$14"$11,$12,,,,,3 endl index.. .,0,1 else index.. .,$3,1 fi rm. fi 
 endl
 l[1] ${AlpC},1,1,1 f. "x" n. 0,255 index.. .,${AlpD},1 rm. endl a c
 if $7 r {100*$8}%,{100*$9}%,1,4,1 fi


### PR DESCRIPTION
1. Now pal -1 will accept any palettes that is created regardless of dimension as long as the base palette color has no duplicates, so pal db32 rv pal -1 is equal to pal db32 which is also equivalent to pal db32 pal -1 . This makes color transferring with the benefits of lctwp easy.

2. lctwp command received new features to wrap it up for the upcoming 8-bit color transfer filter. It now has the option of altering pixel ratio, and restrict colors by tile size, and both of these are necessary to stimulate older system or just 'stylizing' the work.