### PR TITLE
iain_png_processing: Use resize_as_image

### DIFF
--- a/include/iain_fergusson.gmic
+++ b/include/iain_fergusson.gmic
@@ -4174,7 +4174,7 @@ endif
    elif $dither_pattern==0
    (0;255)
    endif
-  resize[-1] [0],0,2
+  resize_as_image[-1] [0],0,2
   channels[-1] 0
   append[-1,-2] c
   blend alpha


### PR DESCRIPTION
This fixes the line and checkerboard dither patterns in new versions of G'MIC.