### PR TITLE
fixed bug and added "Pen Drawing" checkbox

### DIFF
--- a/include/claude_lion.gmic
+++ b/include/claude_lion.gmic
@@ -332,7 +332,7 @@ cl_lineart:
 			if $type==0
 				fx_curves_interactive. 7,0,1,"7","0,0,60,0,80,100,100,100,-1,0,0,100,0,-1,0,0,100,100,-1,0,0,100,100,-1"
 			elif $type==1
-				if s==2 split_opacity. rm. fi
+				remove_opacity.
 				+colormap. 8
 				index.. [-1],0,1
 				rm.

--- a/include/claude_lion.gmic
+++ b/include/claude_lion.gmic
@@ -267,13 +267,14 @@ cl_comic_preview :
 #@gui : Type = choice(2, "Soft Threshold", "Gray Patches", "Lines and Black", "Black and Lines")
 #@gui : sep = separator()
 #@gui : Final Antialias = choice(2, "None", "Light Simple", "Simple", "Very Strong")
+#@gui : Pen Drawing = bool(0)
 #@gui : sep = separator()
 #@gui : Preview Type = choice("Full","Forward Horizontal","Forward Vertical","Backward Horizontal",
 #@gui : "Backward Vertical","Duplicate Top","Duplicate Left","Duplicate Bottom","Duplicate Right",
 #@gui : "Duplicate Horizontal","Duplicate Vertical","Checkered","Checkered Inverse")
 #@gui : Preview Split = point(50,50,0,0,200,200,200,0,10)_0
 #@gui : sep = separator()
-#@gui : url = link("Filter discussed here","http://gimpchat.com/viewtopic.php?f=15&t=5328&start=10#p270912")
+#@gui : url = link("Filter discussed here","http://gimpchat.com/viewtopic.php?f=15&t=5328&start=20#p272779")
 #@gui : note = note("<small>Author: <i>Claude Lion</i>.      Latest Update: <i>2022/04/06</i>.</small>")
 #@gui : note = note("<small>It uses filters of David Tschumperlé and a few filters of Jérôme Boulanger.</small>")
 #@gui : note = note("<small>Type='Lines and Black' is a shortcut of 'Black and Lines' with 'Local Contrast Enhancement = 1' and 'Luminosity Increase = 40'. In this case, 'Local Contrast Enhancement' and 'Luminosity Increase' cursors have no effect.</small>")
@@ -290,6 +291,7 @@ cl_lineart:
 	antialias=$9
 	type=$10
 	finalAntialias=$11
+	penDrawing=$12
 
 	foreach {
 
@@ -358,6 +360,15 @@ cl_lineart:
 		elif $finalAntialias==3
 			fx_smooth_antialias. 100,0.5,5,0,50,50
 			fx_smooth_antialias. 100,0.5,5,0,50,50
+		fi
+
+		if $penDrawing==1
+			fx_pen_drawing. 10,0,50,50
+			n 0,255
+			otsu 4
+			n 0,255
+			fx_smooth_antialias. 15,0,1,0,50,50
+			fx_smooth_antialias. 50,50,2.5,0,50,50
 		fi
 
 	}


### PR DESCRIPTION
- fixed a bug: When the original image had an alpha channel and "type=Gray Patches" was selected, the result was transparent.
- added "Pen Drawing" checkbox.