### PR TITLE
Improvement of "Comic Book" and "Line Art"

### DIFF
--- a/include/claude_lion.gmic
+++ b/include/claude_lion.gmic
@@ -41,7 +41,7 @@
 #
 
 #@gui _<b>Artistic</b>
-#@gui Comic Book: cl_comic, cl_comic_preview(0)
+#@gui Comicbook: cl_comic, cl_comic_preview(0)
 #@gui : note = note("<b>Note</b>: Photo to cartoon")
 #@gui : sep = separator()
 #@gui : note = note(" ")
@@ -60,13 +60,14 @@
 #@gui : Luminosity Increase = int(10,0,50)
 #@gui : Saturation Increase = int(20,0,50)
 #@gui : Final Flattening (bilateral) = int(6,0,10)
-#@gui : Color Effect = choice(0, "None", "Deep Black", "Local Contrast Enhancement", "Colorful")
+#@gui : Color Effect = choice(2, "None", "Deep Black", "Local Contrast Enhancement", "Colorful")
 #@gui : Flat Color Effect = choice(0, "None", "Rainbow", "Hard Rainbow", "Posterize Softly", "Super Flat")
 #@gui : Colors to Black or White = choice(0, "No", "Soft Threshold", "Threshold with Soft Antialias", "Lines and Black")
 #@gui : sep = separator()
 #@gui : Relief Effect = choice(0, "None", "Groove", "Bump")
+#@gui : Special Effect = choice(0, "None", "Dream", "Past", "Sketch of Future")
 #@gui : sep = separator()
-#@gui : Final Antialias = bool(0)
+#@gui : Final Antialias = choice(0, "None", "Simple", "Double")
 #@gui : sep = separator()
 #@gui : Preview Type = choice("Full","Forward Horizontal","Forward Vertical","Backward Horizontal",
 #@gui : "Backward Vertical","Duplicate Top","Duplicate Left","Duplicate Bottom","Duplicate Right",
@@ -74,7 +75,7 @@
 #@gui : Preview Split = point(50,50,0,0,200,200,200,0,10)_0
 #@gui : sep = separator()
 #@gui : url = link("Filter discussed here","http://gimpchat.com/viewtopic.php?f=11&t=19335&p=266517#p266512")
-#@gui : note = note("<small>Author: <i>Claude Lion</i>.      Latest Update: <i>2022/05/02</i>.</small>")
+#@gui : note = note("<small>Author: <i>Claude Lion</i>.      Latest Update: <i>2022/05/10</i>.</small>")
 #@gui : note = note("<small>It uses filters of David Tschumperlé and a few filters of Jérôme Boulanger.</small>")
 cl_comic :
 	foreach {
@@ -94,7 +95,8 @@ cl_comic :
 	flatColorEffect=$13
 	bw=$14
 	reliefEffect=$15
-	finalAntialias=$16
+	specialEffect=$16
+	finalAntialias=$17
 
 	if $simplif==2
 		fx_smooth_antialias. 100,0,2.5,0,50,50
@@ -197,6 +199,7 @@ cl_comic :
 
 
 
+		remove_opacity.
 		if $bw==1
 			fx_curves_interactive. 7,0,1,"7","0,0,16,100,100,100,-1,0,0,100,0,-1,0,0,100,100,-1,0,0,100,100,-1"
 		elif $bw==2
@@ -241,7 +244,37 @@ cl_comic :
 		crop. 2,2,{w-4},{h-4}
 	fi
 
+	if $specialEffect==1
+		+blur. 12.5
+		add[-2,-1] *. 0.8 add. 40
+		cut. 0,255
+		fx_smooth_antialias. 100,2,5,0,50,50
+		fx_frame_fuzzy. 12,12,30,5,255,255,255,255
+		jeje_clouds. 50,0.5
+	elif $specialEffect==2
+		fx_curves_interactive. 7,0,1,"7","0,0,100,100,-1,0,0,65,35,100,100,-1,0,0,50,50,100,100,-1,0,0,100,100,-1"
+		fx_stripes_y. 4,0,0,0,50,50
+		fx_simulate_grain. 0,1,0.2,100,0,0,0,0,0,0,0,0,0
+		fx_dirty. 1,1,0,0,0,50,50
+	elif $specialEffect==3
+		+fx_smooth_antialias. 100,0,5,0,50,50
+		fx_smooth_antialias. 100,0,5,0,50,50
+		fx_smooth_antialias. 100,0,5,0,50,50
+		fx_hardsketchbw. 80,100,1,0.1,50,0,0,0,50,50
+		fx_smooth_antialias. 100,0,5,0,50,50
+		fx_smooth_antialias. 100,0,5,0,50,50
+		otsu. 4 n. 0,255
+		fx_smooth_antialias. 15,0,1,0,50,50
+		fx_smooth_antialias. 50,50,2.5,0,50,50
+		blur.. 10
+		fx_smooth_bilateral.. 10,7,6,0,0
+		mul[-2,-1] n. 0,255
+	fi
+
 	if $finalAntialias==1
+		fx_smooth_antialias 50,50,2.5,0,50,50
+	elif $finalAntialias==2
+		fx_smooth_antialias. 15,0,1,0,50,50
 		fx_smooth_antialias 50,50,2.5,0,50,50
 	fi
 
@@ -251,7 +284,7 @@ cl_comic_preview :
   gui_split_preview "cl_comic $*",${-3--1}
 
 
-#@gui Line Art: cl_lineart, cl_lineart_preview(0)
+#@gui Lineart: cl_lineart, cl_lineart_preview(0)
 #@gui : note = note("<b>Photo to Line Art</b>")
 #@gui : sep = separator()
 #@gui : note = note(" ")
@@ -273,13 +306,15 @@ cl_comic_preview :
 #@gui : Final Antialias = choice(2, "None", "Light Simple", "Simple", "Very Strong")
 #@gui : Pen Drawing = choice(0, "None", "Simple", "Undoing Patterns")
 #@gui : sep = separator()
+#@gui : Effect = choice(0, "None", "Charcoal", "Groove")
+#@gui : sep = separator()
 #@gui : Preview Type = choice("Full","Forward Horizontal","Forward Vertical","Backward Horizontal",
 #@gui : "Backward Vertical","Duplicate Top","Duplicate Left","Duplicate Bottom","Duplicate Right",
 #@gui : "Duplicate Horizontal","Duplicate Vertical","Checkered","Checkered Inverse")
 #@gui : Preview Split = point(50,50,0,0,200,200,200,0,10)_0
 #@gui : sep = separator()
 #@gui : url = link("Filter discussed here","http://gimpchat.com/viewtopic.php?f=15&t=5328&start=20#p272779")
-#@gui : note = note("<small>Author: <i>Claude Lion</i>.      Latest Update: <i>2022/05/02</i>.</small>")
+#@gui : note = note("<small>Author: <i>Claude Lion</i>.      Latest Update: <i>2022/05/10</i>.</small>")
 #@gui : note = note("<small>It uses filters of David Tschumperlé and a few filters of Jérôme Boulanger.</small>")
 #@gui : note = note("<small>Type='Lines and Black' is a shortcut of 'Black and Lines' with 'Local Contrast Enhancement = 1' and 'Luminosity Increase = 40'. In this case, 'Local Contrast Enhancement' and 'Luminosity Increase' cursors have no effect.</small>")
 
@@ -296,6 +331,7 @@ cl_lineart:
 	type=$10
 	finalAntialias=$11
 	penDrawing=$12
+	effect=$13
 
 	foreach {
 
@@ -377,6 +413,31 @@ cl_lineart:
 			n 0,255
 			fx_smooth_antialias. 15,0,1,0,50,50
 			fx_smooth_antialias. 50,50,2.5,0,50,50
+		fi
+
+		if $effect==1
+			fx_spread. 2,2,0,0,0,50,50
+		elif $effect==2
+			# inspired by emboss_image of Reptorian
+			+fx_curves_interactive. 7,0,1,"7","0,0,16,100,100,100,-1,0,0,100,0,-1,0,0,100,100,-1,0,0,100,100,-1"
+			l.
+				b. 3
+				gradient2rgb. 0 n. 0,255
+				[-1]
+				rgb2hsv[-2,-1] split[-2,-1] c
+
+				l[-3--1] +[-3] {315} %[-3] 360 done
+				l[-6--4] +[-3] {135} %[-3] 360 done
+				l[-3--1] a c hsv2rgb s c done
+				l[-6--4] a c hsv2rgb s c done
+				rm[^-6,-3]
+				negate..
+				/ 2
+				+. 128
+				blend grainmerge,1
+			done
+			to_rgb
+			blend grainmerge,1
 		fi
 
 	}


### PR DESCRIPTION
Fixed a bug in "Comic Book" and "Line Art"
---------
I've recently changed the place of "Line Antialias". Unfortunately, if a user has already chosen options for the filter, this user will be unpleasantly surprised to realize that the results are very different than expected (In fact, the chosen options are now applied to the wrong parameters).
So, I've changed the name of both the filters to force them to reinitialize the parameters.
"Comic Book" -> "Comicbook"
"Line Art" -> "Lineart"

Improvement of "Comic Book"
-------------------
- added a new parameter("Special Effect") with these options: "Dream", "Past", "Sketch of Future"
- replaced the "Final Antialias" checkbox by a dropdown listbox with two options: "Simple", "Double"
- changed default for "Color Effect" parameter: Now, it's "Local Contrast Enhancement"

Improvement of "Line Art"
-------------------
- added a "Charcoal" and a "Groove" option to a new "Effect" parameter